### PR TITLE
Improve robustness when given degenerate q profiles

### DIFF
--- a/Iterate.py
+++ b/Iterate.py
@@ -133,8 +133,9 @@ def iterate(si, st):
 
     # Set qpllu1 to lowest q value in array. 
     # Prevents unphysical results when ODEINT bugs causing negative q in middle but still positive q at end, fooling solver to go in wrong direction
+    # Sometimes this also creates a single NaN which breaks np.min(), hence nanmin()
     if len(st.q[st.q<0]) > 0:
-        st.qpllu1 = np.min(st.q) # minimum q
+        st.qpllu1 = np.nanmin(st.q) # minimum q
     else:
         st.qpllu1 = st.q[-1] # upstream q
 

--- a/LRBv21.py
+++ b/LRBv21.py
@@ -387,6 +387,7 @@ def LRBv21(constants,radios,d,SparRange,
                 Qrad.append(((si.nu0**2*st.Tu**2)/Tf**2)*si.cz0*si.Lfunc(Tf))
             
         output["Rprofiles"].append(Qrad)
+        output["Qprofiles"].append(st.q)
         output["logs"].append(st.log)
         
     """------COLLECT RESULTS------"""


### PR DESCRIPTION
During the convergence process q can sometimes become negative in part of the domain. When this happens, ODEINT does something strange and creates a discontinuity in the q profile:

![image](https://github.com/cydcowley/DLS-model/assets/62797494/d0a5d091-7083-45ed-bf58-f1206ed4f5dd)

This is problematic because without this discontinuity the upstream q would be negative, and so the sign of the error is made incorrect. This causes the solver to go in the wrong direction and lead to even more negative q profiles which makes the discontinuity worse until it gets stuck.

This problem took me quite some time to work out originally. The fix is to accept this discontinuity, but when there are any negative q regions in the domain to calculate the error based on the **minimum** q in the domain instead of the upstream q. This ensures the error is the correct sign and makes the algorithm steer away from this region and continue to convergence. It's implemented here:

https://github.com/cydcowley/DLS-model/blob/737539b3c047ac38aa1fe83df7259faf235feb0e/Iterate.py#L134-L139

Turns out that sometimes in addition to this discontinuity ODEINT can insert a `NaN` exactly at the discontinuity point, which breaks line 137 in the above and causes `error1` to become `NaN`, breaking the convergence. This seems to have been quite rare. This PR fixes this by allowing `NaN` handling through `np.nanmin()`:

https://github.com/cydcowley/DLS-model/blob/661f1d1391d153225c4e43ff312b0f19a5c93dff/Iterate.py#L134-L140

**NOTE** this has the `refactor` branch merged so the `refactor` branch should be merged with master first.

