### PR TITLE
Implement dynamic grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /__pychache__/
 *.png
+*.pyc
 LengFunc.m
 runLeng.m
 LengyelSolver.py

--- a/DLScommonTools.py
+++ b/DLScommonTools.py
@@ -8,17 +8,13 @@ from unpackConfigurationsMK import *
 from matplotlib.collections import LineCollection
 import os
 import pickle as pkl
-from LRBv21 import LRBv21
 import matplotlib as mpl
 import copy
 # import colorcet as cc
 from scipy import interpolate
 from matplotlib.ticker import FormatStrFormatter, StrMethodFormatter, MultipleLocator, FormatStrFormatter, AutoMinorLocator
 
-# from unpackConfigurations import unpackConfiguration
-# from LengyelReinkeFormulation import *
-# import ThermalFrontFormulation as TF
-# from LRBv2 import LRBv2
+
 
 def scale_BxBt(Btot, Xpoint, scale_factor = 0, BxBt = 0):
 # Scale a Btot profile to have an arbitrary flux expansion
@@ -275,6 +271,20 @@ def make_colors(number, cmap):
 def mike_cmap(number):
     colors = ["teal", "darkorange", "firebrick",  "limegreen", "magenta","cyan", "navy"]
     return colors[:number]
+
+def pad_profile(S, data):
+    """
+    DLS terminates the domain at the front meaning downstream domain is ignored.
+    This adds zeros to a result array data to fill those with zeros according to 
+    the distance array S.
+    """
+
+    intended_length = len(S)
+    actual_length = len(data)
+
+    out = np.insert(data, 0, np.zeros((intended_length - actual_length)))
+    
+    return out
 
 def set_matplotlib_defaults():
     fontsize = 14

--- a/LRBv21.py
+++ b/LRBv21.py
@@ -387,6 +387,8 @@ def LRBv21(constants,radios,d,SparRange,
                 Qrad.append(((si.nu0**2*st.Tu**2)/Tf**2)*si.cz0*si.Lfunc(Tf))
             
         output["Rprofiles"].append(Qrad)
+        output["Qprofiles"].append(st.q)
+        output["Tprofiles"].append(st.T)
         output["logs"].append(st.log)
         
     """------COLLECT RESULTS------"""

--- a/LRBv21.py
+++ b/LRBv21.py
@@ -437,9 +437,10 @@ def LRBv21(constants,radios,d,SparRange,
         output["crel"] = crel_list
         output["cvar_trim"] = cvar_list_trim
         output["crel_trim"] = crel_list_trim
-        output["threshold"] = cvar_list[0]
-        output["window"] = cvar_list[-1] - cvar_list[0]
-        output["window_ratio"] = cvar_list[-1] / cvar_list[0]
+        output["threshold"] = cvar_list[0]                                # Ct
+        output["window"] = cvar_list[-1] - cvar_list[0]                   # Cx - Ct
+        output["window_frac"] = output["window"] / output["threshold"]    # (Cx - Ct) / Ct
+        output["window_ratio"] = cvar_list[-1] / cvar_list[0]             # Cx / Ct
 
         output["constants"] = constants
         output["radios"] = si.radios

--- a/LRBv21.py
+++ b/LRBv21.py
@@ -201,7 +201,8 @@ def LRBv21(constants,radios,d,SparRange,
                              timeout = 20,
                              dynamicGrid = False,
                              dynamicGridRefinementRatio = 5,
-                             dynamicGridRefinementWidth = 2,
+                             dynamicGridRefinementWidth = 1,
+                             dynamicGridDiagnosticPlot = False
                              ):
     """ function that returns the impurity fraction required for a given temperature at the target. Can request a low temperature at a given position to mimick a detachment front at that position.
     constants: dict of options
@@ -273,16 +274,17 @@ def LRBv21(constants,radios,d,SparRange,
             newProfile = refineGrid(d, SparFront, 
                                     fine_ratio = dynamicGridRefinementRatio, 
                                     width = dynamicGridRefinementWidth,
-                                    diagnostic_plot = False)
+                                    diagnostic_plot = dynamicGridDiagnosticPlot)
             si.Xpoint = newProfile["Xpoint"]
             si.S = newProfile["S"]
             si.Spol = newProfile["Spol"]
             si.Btot = newProfile["Btot"]
+            si.Bpol = newProfile["Bpol"]
             si.B = interpolate.interp1d(si.S, si.Btot, kind = "cubic")   # TODO: is this necessary?  We have Btot already
             
-            # Find nearest point on new grid
-            old_S = si.SparRange[idx]
-            point = st.point = np.argmin(abs(si.S - old_S))
+            # Find index of front location on new grid
+            SparFrontOld = si.SparRange[idx]
+            point = st.point = np.argmin(abs(si.S - SparFrontOld))
         
         else:
             point = st.point = np.argmin(abs(d["S"] - SparFront))  
@@ -432,6 +434,8 @@ def LRBv21(constants,radios,d,SparRange,
         output["Tprofiles"].append(st.T)
         output["Sprofiles"].append(si.S)
         output["Spolprofiles"].append(si.Spol)
+        output["Btotprofiles"].append(si.Btot)
+        output["Bpolprofiles"].append(si.Bpol)
         output["logs"].append(st.log)
         
     """------COLLECT RESULTS------"""

--- a/refineGrid.py
+++ b/refineGrid.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import scipy as sp
 import matplotlib.pyplot as plt
@@ -86,7 +85,7 @@ def refineGrid(p,
     ## Interpolate geometry and field onto the new S coordinate
     pnew = {}
     pnew["S"] = Snew
-    for par in p.keys():
+    for par in ["S", "Spol", "R", "Z", "Btot", "Bpol"]:
         if par != "Xpoint" and par != "S":
             pnew[par] = sp.interpolate.make_interp_spline(S, p[par], k = 2)(Snew)
             

--- a/refineGrid.py
+++ b/refineGrid.py
@@ -1,0 +1,77 @@
+
+import numpy as np
+import scipy as sp
+import matplotlib.pyplot as plt
+
+def refineGrid(p, Sfront, fine_ratio = 2, width = 2, resolution = None, diagnostic_plot = False):
+    """
+    Refines the grid around the front location.
+    Refinement is in the form of a Gaussian distribution
+    with a peak determined by fine_ratio and a given width.
+    
+    Inputs
+    -----
+    p: dict
+        Dictionary containing the profile data (S, Spol, Btot, Bpol, Xpoint, R, Z)
+    fine_ratio: float, default 2
+        Ratio of coarse cell size to fine cell size
+    width: float, default 2m
+        Width of the fine region in meters parallel   
+    resolution: float, default None
+        resolution of resulting grid. If None, use same resolution as original grid. 
+    
+    Returns
+    -----
+    pnew: dict
+        New dictionary containing the same profile data as p
+    """
+    
+    S = p["S"]
+
+    ## Create new cell widths and calculate new S array
+    if  resolution == None:
+        resolution = len(S)
+
+    Snew = np.linspace(S[0], S[-1], resolution - 1)      # Estimate of new S. N-1 cause N(0) = 0
+    dSnew = 1/(np.exp(-0.5 * ((Snew - Sfront)/(width))**2) * (fine_ratio-1) + 1)
+    dSnew *= S[-1] / dSnew.sum()      # Normalise to the original S
+    Snew = np.cumsum(np.insert(dSnew, 0, 0))
+    
+    ## Assemble new grid
+    pnew = {}
+    pnew["S"] = Snew
+    for par in p.keys():
+        if par != "Xpoint" and par != "S":
+            pnew[par] = sp.interpolate.make_interp_spline(S, p[par], k = 2)
+
+    pnew["Xpoint"] = np.argmin(np.abs(Snew - S[p["Xpoint"]]))
+    
+    
+    ## Diagnostic plot
+    if diagnostic_plot is True:
+        fig, axes = plt.subplots(1,3, figsize = (15,5), dpi = 100)
+
+        axes[0].plot(S, Snew, marker = "o", lw = 0)
+        axes[0].plot(S, S, ls = "--", c = "k", lw = 1)
+        axes[0].set_xlabel("Old Spar")
+        axes[0].set_ylabel("New Spar")
+        axes[0].set_title("Old vs. new Spar map")
+
+        axes[1].plot(Snew[1:], dSnew)
+        axes[1].set_xlabel("S")
+        axes[1].set_ylabel("dS")
+        axes[1].set_title("Grid width profile")
+
+        axes[2].set_title("Btot profile")
+        axes[2].plot(S, p["Btot"], marker = "o", lw = 0, ms = 6, markerfacecolor = "None", c = "darkorange", label = "Original")
+        axes[2].plot(S, interpfun(S), c = "darkorange", lw = 1, label = "Original, interpolated")
+        axes[2].plot(Snew, pnew["Btot"], marker = "o", ms = 3, lw = 0, label = "New grid")
+        axes[2].scatter(S[p["Xpoint"]], p["Btot"][p["Xpoint"]], c = "r", label = "Old Xpoint", zorder = 100, s = 150, linewidths=1, marker = "x")
+        axes[2].scatter(Snew[pnew["Xpoint"]], pnew["Btot"][pnew["Xpoint"]], c = "blue", label = "New Xpoint", zorder = 100, s = 250, linewidths=1, marker = "+")
+        axes[2].set_xlabel("S [m]")
+        axes[2].set_ylabel("Btot [T]")
+        
+        axes[2].legend(fontsize = 12)
+        fig.tight_layout()
+        
+    return pnew

--- a/refineGrid.py
+++ b/refineGrid.py
@@ -65,7 +65,7 @@ def refineGrid(p,
             break
         
         if i == timeout-1:
-            raise Exception("Iterative grid adaption iteration limit reached, try running with diagnostic plot")
+            raise Exception("Iterative grid adaption iteration limit reached, try reducing refinement ratio and running with diagnostic plot")
     
     Snew = np.insert(Snew, 0, 0)   # len(dS) = len(S) - 1
     

--- a/unpackConfigurationsMK.py
+++ b/unpackConfigurationsMK.py
@@ -11,8 +11,7 @@ def unpackConfigurationMK(File,
                           resolution = 300, 
                           convention = "target_to_midplane", 
                           diagnostic_plot = False,
-                          absolute_B = True,
-                          log_grid = False):
+                          absolute_B = True):
     """
     Extract interpolated variables along the SOL for connected double null configurations
     File = balance file path
@@ -194,32 +193,6 @@ def unpackConfigurationMK(File,
             d["Bpol"] = abs(d["Bpol"])
         
         d["Spol"] = np.array(returnll(d["R"], d["Z"]))
-        
-        if log_grid == True:
-        # Create log grid from Xpoint to target in Spol space. Half the res goes above and half
-        # goes below the Xpoint. This is much easier to do after the transformations above
-        # because Spol and Xpoints exist and they're all in the right convention.
-
-            Xpoint = d["Xpoint"]
-            # print("side:",side,d["Spol"][Xpoint+1])
-            dymin = 0.001 # size of cell at the target
-            abovex = np.linspace(d["Spol"][Xpoint], d["Spol"][-1],
-                                 int(np.floor(resolution/2)))
-            belowx = np.logspace(np.log10(dymin), np.log10(d["Spol"][Xpoint]),
-                                 int(np.ceil(resolution/2)))
-            belowx = np.insert(belowx, 0, 0) # logspace won't go to 0. Ensure there is one
-            belowx = np.delete(belowx, -1) # Delete duplicate point shared with abovex
-            path_grid_log = np.concatenate([belowx, abovex])
-            
-            # STILL OKAY AT THIS POINT
-
-            # Reinterpolate the grid and redo all the transformations
-            for param in full.keys():
-                loginterp = interpolate.interp1d(d["Spol"], d[param])
-                d[param] = loginterp(path_grid_log)
-     
-            d["Spol"] = path_grid_log
-            d["Xpoint"] = len(belowx)
             
         
         # Assemble all the output variables

--- a/unpackConfigurationsMK.py
+++ b/unpackConfigurationsMK.py
@@ -192,22 +192,12 @@ def unpackConfigurationMK(File,
             d["Btot"] = abs(d["Btot"])
             d["Bpol"] = abs(d["Bpol"])
         
+        # Poloidal distance
         d["Spol"] = np.array(returnll(d["R"], d["Z"]))
             
         
-        # Assemble all the output variables
-        d["Bx"] = d["Btot"][d["Xpoint"]]
-        d["zl"] = np.array(returnzl(d["R"], d["Z"], d["Bx"], np.absolute(d["Bpol"])))
-        d["zx"] = d["zl"][d["Xpoint"]]   
-        d["S"] = np.array(returnS(d["R"], d["Z"], d["Btot"], d["Bpol"]))
-        d["Sx"] = d["S"][d["Xpoint"]]
-        d["Spolx"] = d["Spol"][d["Xpoint"]]
-
-        # Full arrays of R and Z
-        d["R_full"] = Rs
-        d["Z_full"] = Zs
-        d["R_ring"] = Rs[sep]
-        d["Z_ring"] = Zs[sep]
+        # Z space distance (combined parallel and flux expansion, see Lipschultz 2016)
+        d["zl"] = np.array(returnzl(d["R"], d["Z"], d["Btot"][d["Xpoint"]], np.absolute(d["Bpol"])))
         
 
     """------OUTPUT"""    
@@ -286,3 +276,4 @@ def returnzl(R,Z, BX, Bpol):
         PrevR = R[i]
         PrevZ = Z[i]
     return zl
+

--- a/unpackConfigurationsMK.py
+++ b/unpackConfigurationsMK.py
@@ -194,7 +194,7 @@ def unpackConfigurationMK(File,
         
         # Poloidal distance
         d["Spol"] = np.array(returnll(d["R"], d["Z"]))
-            
+        d["S"] = np.array(returnS(d["R"], d["Z"], d["Btot"], d["Bpol"]))
         
         # Z space distance (combined parallel and flux expansion, see Lipschultz 2016)
         d["zl"] = np.array(returnzl(d["R"], d["Z"], d["Btot"][d["Xpoint"]], np.absolute(d["Bpol"])))


### PR DESCRIPTION
The original grid scheme calculates the domain by taking the R,Z coordinates from SOLPS, which ends up being roughly constant cell width in the poloidal but very much not so in the parallel. This results in very poor resolution near the X-point which makes radiation profile post-processing challenging but doesn't seem to affect the detachment threshold/window results.

Enter the dynamic grid, which takes any domain and rescales it to a given number of points with a refinement region defined by a user-set gaussian. This has to be done iteratively - you start with a uniform grid and calculate grid widths that get narrower at a defined parallel distance, then you do a cumulative sum to get the array of parallel distances, at which point the widths no longer correspond to the distances. A loop goes between the widths and the lengths until the answer stops changing by a tolerance (1e-3 by default). The algorithm is not always stable - extreme refinements at high point counts can cause it to diverge, at which point it raises an exception with helpful verbosity. It takes slightly silly settings to make it go unstable so I think it's fine. 

Here's a plot of the iterative process with a plot of grid widths on the top and a scatter of the parallel lengths, with iterations advancing from top to bottom:

![image](https://github.com/cydcowley/DLS-model/assets/62797494/6a2c0695-473f-4dc0-8b5c-73046376541c)

The algorithm is very fast and doesn't seem to affect runtime. On the contrary, it allows you to run with a lot fewer points than before to get the same solution. I'm running with 2000 points and 40x refinement, and this is resulting in far, far better resolution than even 100k points on a poloidally uniform grid. That means for the same resolution we're looking at a performance improvement of several hundred times.

To accommodate the scheme, the main loop had to be changed to iterate on the prescribed parallel front distances instead of index positions. This is because the index position for a particular front position changes as each front position has a unique grid. This also means that profiles of distances and B fields are unique per front position and have to be saved alongside other profiles. This will break existing analysis scripts and so the scheme is disabled by default. We can change it to be enabled by default when we redo the example notebooks.

Settings:

- dynamicGrid = False by default to preserve legacy scripts, enables scheme
- dynamicGridRefinementRatio = 5 by default, ratio of coarsest to finest cell size
- dynamicGridRefinementWidth = 1 by default, width of fine region in m parallel
- dynamicGridDiagnosticPlot = False by default, shows plots to diagnose issues
