### PR TITLE
Small quality of life improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /__pychache__/
 *.png
+*.pyc
 LengFunc.m
 runLeng.m
 LengyelSolver.py

--- a/DLScommonTools.py
+++ b/DLScommonTools.py
@@ -262,30 +262,6 @@ def file_read(filename):
         
     return data
 
-def make_colors(number, cmap):
-    """make_colors(number of colours, matplotlib colormap function)"""
-    colors = []
-    idx = np.linspace(0,255,number)
-    
-    for i in range(number):
-        colors.append(cmap(int(idx[i])))
-                      
-    return colors
 
-def mike_cmap(number):
-    colors = ["teal", "darkorange", "firebrick",  "limegreen", "magenta","cyan", "navy"]
-    return colors[:number]
-
-def set_matplotlib_defaults():
-    fontsize = 14
-    plt.rc('font', size=fontsize) #controls default text size
-    plt.rc('axes', titlesize=fontsize) #fontsize of the title
-    plt.rc('axes', labelsize=fontsize) #fontsize of the x and y labels
-    plt.rc('xtick', labelsize=fontsize) #fontsize of the x tick labels
-    plt.rc('ytick', labelsize=fontsize) #fontsize of the y tick labels
-    plt.rc('legend', fontsize=fontsize) #fontsize of the legend
-    plt.rc('lines', linewidth=3)
-    plt.rc('figure', figsize=(8,6))
-    plt.rc('axes', grid = True)
     
     

--- a/DLScommonTools.py
+++ b/DLScommonTools.py
@@ -264,4 +264,16 @@ def file_read(filename):
 
 
     
-    
+def pad_profile(S, data):
+    """
+    DLS terminates the domain at the front meaning downstream domain is ignored.
+    This adds zeros to a result array data to fill those with zeros according to 
+    the distance array S.
+    """
+
+    intended_length = len(S)
+    actual_length = len(data)
+
+    out = np.insert(data, 0, np.zeros((intended_length - actual_length)))
+
+    return out

--- a/LRBv21.py
+++ b/LRBv21.py
@@ -387,6 +387,8 @@ def LRBv21(constants,radios,d,SparRange,
                 Qrad.append(((si.nu0**2*st.Tu**2)/Tf**2)*si.cz0*si.Lfunc(Tf))
             
         output["Rprofiles"].append(Qrad)
+        output["Qprofiles"].append(st.q)
+        output["Tprofiles"].append(st.T)
         output["logs"].append(st.log)
         
     """------COLLECT RESULTS------"""

--- a/LRBv21.py
+++ b/LRBv21.py
@@ -437,9 +437,10 @@ def LRBv21(constants,radios,d,SparRange,
         output["crel"] = crel_list
         output["cvar_trim"] = cvar_list_trim
         output["crel_trim"] = crel_list_trim
-        output["threshold"] = cvar_list[0]
-        output["window"] = cvar_list[-1] - cvar_list[0]
-        output["window_ratio"] = cvar_list[-1] / cvar_list[0]
+        output["threshold"] = cvar_list[0]                                # Ct
+        output["window"] = cvar_list[-1] - cvar_list[0]                   # Cx - Ct
+        output["window_frac"] = output["window"] / output["threshold"]    # (Cx - Ct) / Ct
+        output["window_ratio"] = cvar_list[-1] / cvar_list[0]             # Cx / Ct
 
         output["constants"] = constants
         output["radios"] = si.radios


### PR DESCRIPTION
This PR:

- Updates .gitignore to take out .pyc files
- Adds heat flux and temperature profiles for each front position to the output 
- Adds the detachment window fraction to the output and adds clarifying comments on the definition of threshold and the different detachment window options
- Takes out my personal Matplotlib styles which were left in by accident some months ago
- Adds tool to pad profiles (e.g. temperature, radiation, etc) with zeros so that their total len() is the same as the underlying profile. this is necessary because the DLS solves for a domain that terminates at the front and so the profiles do as well.