### PR TITLE
Use `scipy.integrate.trapezoid` instead of `numpy.trapezoid`

### DIFF
--- a/src/fusiondls/Iterate.py
+++ b/src/fusiondls/Iterate.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.integrate import solve_ivp
+from scipy.integrate import solve_ivp, trapezoid
 
 from .unpackConfigurationsMK import *
 
@@ -127,7 +127,7 @@ def iterate(si, st):
         st.nu = st.cvar
 
     # si.Btot = [si.B(x) for x in si.S]   ## FIXME This shouldn't be here, we already have a Btot
-    st.qradial = (si.qpllu0 / si.Btot[si.Xpoint]) / np.trapezoid(
+    st.qradial = (si.qpllu0 / si.Btot[si.Xpoint]) / trapezoid(
         1 / si.Btot[si.Xpoint :], x=si.S[si.Xpoint :]
     )
 
@@ -135,7 +135,7 @@ def iterate(si, st):
         st.cz = si.cz0
         st.nu = si.nu0
         # st.qradial = 1/st.cvar # This is needed so that too high a cvar gives positive error
-        st.qradial = (1 / st.cvar / si.Btot[si.Xpoint]) / np.trapezoid(
+        st.qradial = (1 / st.cvar / si.Btot[si.Xpoint]) / trapezoid(
             1 / si.Btot[si.Xpoint :], x=si.S[si.Xpoint :]
         )
 

--- a/src/fusiondls/LRBv21.py
+++ b/src/fusiondls/LRBv21.py
@@ -3,7 +3,7 @@ from timeit import default_timer as timer
 
 import numpy as np
 from scipy import interpolate
-from scipy.integrate import cumulative_trapezoid
+from scipy.integrate import cumulative_trapezoid, trapezoid
 
 from .DLScommonTools import pad_profile
 from .Iterate import iterate
@@ -365,8 +365,8 @@ def LRBv21(
             # nu0 and cz0 guesses are from Lengyel which depends on an estimate of Tu using qpllu0
             # This means we cannot make a more clever guess for qpllu0 based on cz0 or nu0
             qpllu0_guess = si.qpllu0
-            # qradial_guess = qpllu0_guess / np.trapezoid(si.Btot[si.Xpoint:] / si.Btot[si.Xpoint], x = si.S[si.Xpoint:])
-            qradial_guess = (qpllu0_guess / si.Btot[si.Xpoint]) / np.trapezoid(
+            # qradial_guess = qpllu0_guess / trapezoid(si.Btot[si.Xpoint:] / si.Btot[si.Xpoint], x = si.S[si.Xpoint:])
+            qradial_guess = (qpllu0_guess / si.Btot[si.Xpoint]) / trapezoid(
                 1 / si.Btot[si.Xpoint :], x=si.S[si.Xpoint :]
             )
             st.cvar = 1 / qradial_guess
@@ -390,7 +390,7 @@ def LRBv21(
         # Upstream conditions
         st.nu = si.nu0
         st.cz = si.cz0
-        st.qradial = (si.qpllu0 / si.Btot[si.Xpoint]) / np.trapezoid(
+        st.qradial = (si.qpllu0 / si.Btot[si.Xpoint]) / trapezoid(
             1 / si.Btot[si.Xpoint :], x=si.S[si.Xpoint :]
         )
 
@@ -487,17 +487,11 @@ def LRBv21(
         Qrad = []
         for i, Tf in enumerate(st.T):
             if si.control_variable == "impurity_frac":
-                Qrad.append(
-                    ((si.nu0**2 * st.Tu**2) / Tf**2) * st.cvar * si.Lfunc(Tf)
-                )
+                Qrad.append(((si.nu0**2 * st.Tu**2) / Tf**2) * st.cvar * si.Lfunc(Tf))
             elif si.control_variable == "density":
-                Qrad.append(
-                    ((st.cvar**2 * st.Tu**2) / Tf**2) * si.cz0 * si.Lfunc(Tf)
-                )
+                Qrad.append(((st.cvar**2 * st.Tu**2) / Tf**2) * si.cz0 * si.Lfunc(Tf))
             elif si.control_variable == "power":
-                Qrad.append(
-                    ((si.nu0**2 * st.Tu**2) / Tf**2) * si.cz0 * si.Lfunc(Tf)
-                )
+                Qrad.append(((si.nu0**2 * st.Tu**2) / Tf**2) * si.cz0 * si.Lfunc(Tf))
 
         # Pad some profiles with zeros to ensure same length as S
         output["Sprofiles"].append(si.S)

--- a/src/fusiondls/Profile.py
+++ b/src/fusiondls/Profile.py
@@ -3,6 +3,7 @@ import copy
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy as sp
+from scipy.integrate import trapezoid
 
 
 class Profile:
@@ -71,7 +72,7 @@ class Profile:
         Return the integral of the fractional Btot gradient
         below the X-point
         """
-        return np.trapezoid(
+        return trapezoid(
             (np.gradient(self.Btot, self.Spol) / self.Btot)[: self.Xpoint],
             self.Spol[: self.Xpoint],
         )
@@ -88,7 +89,7 @@ class Profile:
         Return the integral of the pitch angle Bpol/Btot
         below the X-point
         """
-        return np.trapezoid(
+        return trapezoid(
             (self.Bpol / self.Btot)[: self.Xpoint], self.Spol[: self.Xpoint]
         )
 


### PR DESCRIPTION
`np.trapz` only replaced by `trapezoid` in 2.0.0, scipy renaming was much earlier (1.10.1)

Fixes #29 