### PR TITLE
Restore definition of `ne` for `fluxlim` case

### DIFF
--- a/src/fusiondls/Iterate.py
+++ b/src/fusiondls/Iterate.py
@@ -73,6 +73,8 @@ def LengFunc(s, y, si, st):
     # Flux limiter
     dtds = 0
     if radios["fluxlim"]:
+        # set density using constant pressure assumption (missing factor of 2 at target due to lack of Bohm condition)
+        ne = nu * Tu / T
         dtds = (
             qoverB
             * fieldValue


### PR DESCRIPTION
Fixes #27

Was removed in edca2731, but I think this was a mistake?