### PR TITLE
Add method to build `MagneticGeometry` from `Profile`

### DIFF
--- a/src/fusiondls/geometry.py
+++ b/src/fusiondls/geometry.py
@@ -1,11 +1,13 @@
 import pickle
 from dataclasses import asdict, dataclass
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import interpolate
 from typing_extensions import Self
 
+from .Profile import Profile
 from .typing import FloatArray, PathLike, Scalar
 
 
@@ -82,6 +84,22 @@ class MagneticGeometry:
         return self.zl[self.Xpoint]
 
     @classmethod
+    def from_profile(cls, profile: Profile) -> Self:
+        """Create a ``MagneticGeometry`` from a ``Profile`` object.
+
+        These classes are expected to be merged in a future build.
+        """
+        return cls(
+            Bpol=profile.Bpol,
+            Btot=profile.Btot,
+            R=profile.R,
+            Z=profile.Z,
+            S=profile.S,
+            Spol=profile.Spol,
+            Xpoint=profile.Xpoint,
+        )
+
+    @classmethod
     def from_pickle(cls, filename: PathLike, design: str, side: str) -> Self:
         """Read a particular design and side from a pickle balance file."""
 
@@ -111,6 +129,9 @@ class MagneticGeometry:
             for k, v in data.items()
             if not (k in cls.__dict__ and isinstance(cls.__dict__[k], property))
         }
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
 
     def B(self, s: float) -> float:
         try:

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,9 +1,10 @@
 import pathlib
+from dataclasses import fields
 
 import numpy as np
 import pytest
 
-from fusiondls import MagneticGeometry
+from fusiondls import MagneticGeometry, Profile, file_read
 
 
 @pytest.fixture(scope="module")
@@ -21,6 +22,35 @@ def test_from_pickle():
     geometry = MagneticGeometry.from_pickle(filename, "V10", "ou")
 
     assert isinstance(geometry, MagneticGeometry)
+
+
+def test_from_profile():
+    filename = (
+        pathlib.Path(__file__).parent.parent / "docs/examples/eqb_store_lores.pkl"
+    )
+    eqb = file_read(filename)
+    outer = eqb["V10"]["ou"]
+    profile = Profile(
+        outer["R"],
+        outer["Z"],
+        outer["Xpoint"],
+        outer["Btot"],
+        outer["Bpol"],
+        outer["S"],
+        outer["Spol"],
+        name="profile",
+    )
+    from_prof = MagneticGeometry.from_profile(profile)
+    from_pkl = MagneticGeometry.from_pickle(filename, "V10", "ou")
+    for field in fields(from_prof):
+        prof_val = from_prof[field.name]
+        pkl_val = from_pkl[field.name]
+        if prof_val is None:
+            # Not all MagneticGeometry fields are present in Profile
+            continue
+        np.testing.assert_allclose(
+            prof_val, pkl_val, err_msg=f"Mismatch in {field.name}"
+        )
 
 
 def test_read_design():


### PR DESCRIPTION
Following the merge of https://github.com/FusionDLS/FusionDLS/pull/39, there's no clear way to get from a `Profile` to running `run_dls`. This adds a method to generate a `MagneticGeometry` from a `Profile`.

A temporary fix until https://github.com/FusionDLS/FusionDLS/issues/58 can be implemented.