### PR TITLE
Add publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Build/publish Python Package
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+      - name: Build package
+        run: |
+          uv build --sdist --wheel
+      - name: Check package
+        run: |
+          uvx twine check dist/*
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fusiondls
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download distribution packages
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Builds on https://github.com/FusionDLS/FusionDLS/pull/73, as the changes to `pyproject.toml` to exclude large files from any built packages is necessary.

Adds a publishing workflow that builds the package and, if we've just made a new release, publishes to PyPI. I still need to configure PyPI to get trusted publishing set up, and I'll follow up with a comment when it's done.

A big problem with these sorts of updates is that you won't know if it has worked until after it's merged and we've tried making a new release. There's nothing stopping us from deleting a release from GitHub though, so we can always try again if there are bugs anywhere.